### PR TITLE
Addition of a kubernetes deployment example and documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ time="2019-01-10T19:57:01Z" level=info msg="Running Snyk API scraper..." source=
 
 # Deployment
 
-To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment yaml in the `examples` folder. You have to add your snyk token and the snyk organizations that you want to get metrics from. The examples assumes that you have a namespace in kubernetes named: `monitoring`. It further assumes that you have [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) configured for you Prometheus instance and a target that will gather metrics from pods, similar to this: 
+To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment and secret yaml in the `examples` folder. You have to add your snyk token in the `secrets.yaml` and/or the snyk organizations that you want to get metrics from in the args section of the `deployment.yaml`. If you don't specify a snyk-organization, the exporter will scrape all organizations the key provides access to. The examples assumes that you have a namespace in kubernetes named: `monitoring`. 
+
+It further assumes that you have [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) configured for you Prometheus instance and a target that will gather metrics from pods, similar to this: 
 
 ```
 - job_name: 'kubernetes-pods'
@@ -124,6 +126,7 @@ To deploy the exporter in Kubernetes, you can find a simple Kubernetes deploymen
 To deploy it to your kubernetes cluster run the following command:
 
 ```
+kubectl apply -f examples/secrets.yaml
 kubectl apply -f examples/deployment.yaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ time="2019-01-10T19:57:01Z" level=info msg="Running Snyk API scraper..." source=
 
 # Deployment
 
-To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment and secret yaml in the `examples` folder. You have to add your snyk token in the `secrets.yaml` and/or the snyk organizations that you want to get metrics from in the args section of the `deployment.yaml`. If you don't specify a snyk-organization, the exporter will scrape all organizations the key provides access to. The examples assumes that you have a namespace in kubernetes named: `monitoring`. 
+To deploy the exporter in Kubernetes, you can find a simple Kubernetes deployment and secret yaml in the `examples` folder. You have to add your snyk token in the `secrets.yaml` and/or the snyk organizations that you want to get metrics from in the args section of the `deployment.yaml`. If you don't specify a snyk-organization, the exporter will scrape all organizations the token provides access to. The examples assumes that you have a namespace in kubernetes named: `monitoring`. 
 
 It further assumes that you have [kubernetes service discovery](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config) configured for you Prometheus instance and a target that will gather metrics from pods, similar to this: 
 
@@ -123,7 +123,7 @@ It further assumes that you have [kubernetes service discovery](https://promethe
     regex: __meta_kubernetes_pod_label_(.+)
 ```
 
-To deploy it to your kubernetes cluster run the following command:
+To deploy it to your kubernetes cluster run the following commands:
 
 ```
 kubectl apply -f examples/secrets.yaml

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -1,0 +1,27 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: snyk-exporter
+  namespace: monitoring
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: snyk-exporter
+  template:
+    metadata:
+      name: snyk-exporter
+      labels:
+        app: snyk-exporter
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9532'
+    spec:
+      containers:
+      - name: snyk-exporter
+        image: quay.io/lunarway/snyk_exporter:v1.0.0
+        args: ["--snyk.api-token", "YOUR_API_TOKEN", "--snyk.organization", "YOU_ORGANIZATION"]
+        ports:
+        - name: scrape
+          containerPort: 9532
+        

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -20,7 +20,13 @@ spec:
       containers:
       - name: snyk-exporter
         image: quay.io/lunarway/snyk_exporter:v1.0.0
-        args: ["--snyk.api-token", "YOUR_API_TOKEN", "--snyk.organization", "YOUR_ORGANIZATION"]
+        args: ["--snyk.api-token", "$(SNYK_API_TOKEN)", "--log.level", "debug"]
+        env:
+        - name: SNYK_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: snyk.api-token
+              name: snyk-exporter
         ports:
         - name: scrape
           containerPort: 9532

--- a/examples/deployment.yaml
+++ b/examples/deployment.yaml
@@ -20,8 +20,7 @@ spec:
       containers:
       - name: snyk-exporter
         image: quay.io/lunarway/snyk_exporter:v1.0.0
-        args: ["--snyk.api-token", "YOUR_API_TOKEN", "--snyk.organization", "YOU_ORGANIZATION"]
+        args: ["--snyk.api-token", "YOUR_API_TOKEN", "--snyk.organization", "YOUR_ORGANIZATION"]
         ports:
         - name: scrape
           containerPort: 9532
-        

--- a/examples/secrets.yaml
+++ b/examples/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: snyk-exporter
+  namespace: monitoring
+data:
+  snyk.api-token: <api-token>


### PR DESCRIPTION
This PR adds a small example of how you can run the exporter in kubernetes. Further it adds instructions on how to use it. 