### PR TITLE
set exit code to 1 on errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	reason := <-done
 	if reason != nil {
 		log.Errorf("Snyk exporter exited due to error: %v", reason)
-		return
+		os.Exit(1)
 	}
 	log.Infof("Snyk exporter exited with exit 0")
 }


### PR DESCRIPTION
Exit code was always 0, even on failure