### PR TITLE
Handle timeouts gracefully

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,11 +6,11 @@ import (
 	neturl "net/url"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
-	"strconv"
-	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -36,7 +36,7 @@ var (
 )
 
 var (
-	ready = false
+	ready      = false
 	readyMutex = &sync.RWMutex{}
 )
 
@@ -77,7 +77,7 @@ func main() {
 		if ready == true {
 			w.WriteHeader(http.StatusOK)
 		} else {
-			w.WriteHeader(http.StatusServiceUnavailable )
+			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 
 		w.Write([]byte(strconv.FormatBool(ready)))

--- a/main_test.go
+++ b/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 func TestAggregateVulnerabilities(t *testing.T) {
@@ -105,5 +108,36 @@ func TestAggregateVulnerabilities(t *testing.T) {
 				t.Errorf("Aggregates are not matching expectations: expected %v got %v", tc.aggregates, output)
 			}
 		})
+	}
+}
+
+func TestRunAPIPolling_issuesTimeout(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		calls++
+		// allow organizations call to succeed
+		if calls == 1 {
+			rw.Write([]byte(`{
+				"orgs": [{
+					"id": "id",
+					"name": "name"
+					}]
+					}`))
+			return
+		}
+		time.Sleep(1 * time.Second)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	done := make(chan error, 1)
+
+	go runAPIPolling(done, server.URL, "token", nil, 20*time.Millisecond, 1*time.Millisecond)
+
+	select {
+	case result := <-done:
+		if result != nil {
+			t.Errorf("unexpected error result: %v", result)
+		}
+	case <-time.After(100 * time.Millisecond):
+		// success path if timeout errors are suppressed
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -121,8 +121,8 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 				"orgs": [{
 					"id": "id",
 					"name": "name"
-					}]
-					}`))
+				}]
+			}`))
 			return
 		}
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
A client timeout should not exit the application if we can avoid it.

Current behaviour will exit on any request errors.
This change set will ignore timeout errors and just log an error in those cases.

There is a bit of formatting changes from gofmt as well.

Closes #13