### PR TITLE
Mark ignored vulnerabilities with "ignored" label

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,13 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 - `project` - The project with a vulnerability
 - `severity` - The severity of the vulnerability, can be `high`, `medium` and `low`
 - `issue_title` - The issue title of the vulnerability, e.g. `Denial os Service (DoS)`. Can be the CVE if the vulnerability is not named by Snyk
+- `ignored` - The issue is ignored in Snyk.
 
 Here is an example.
 
 ```
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_title="Privilege Escalation"} 1.0
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_title="Sandbox (chroot) Escape"} 2.0
+snyk_vulnerabilities_total{ignored="false",organization="my-org",project="my-app",severity="high",issue_title="Privilege Escalation"} 1.0
+snyk_vulnerabilities_total{ignored="true",organization="my-org",project="my-app",severity="low",issue_title="Sandbox (chroot) Escape"} 2.0
 ```
 
 # Build

--- a/snyk.go
+++ b/snyk.go
@@ -144,6 +144,7 @@ type vulnerability struct {
 	ID       string `json:"id,omitempty"`
 	Severity string `json:"severity,omitempty"`
 	Title    string `json:"title,omitempty"`
+	Ignored  bool   `json:"isIgnored"`
 }
 
 type license struct{}


### PR DESCRIPTION
This will allow clients to track ignored vulnerabilities.

Closes #15 

This adds an `ignored` label that can be `true` or `false` in the exported metrics.

```
snyk_vulnerabilities_total{ignored="true",issue_title="XML External Entity (XXE) Injection",organization="Org",project="Project",severity="high"} 1.0
snyk_vulnerabilities_total{ignored="false",issue_title="XML External Entity Injection (XXE)",organization="Org",project="Project",severity="medium"} 1.0
```