### PR TITLE
Add upgradeable and patchable labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 - `severity` - The severity of the vulnerability, can be `high`, `medium` and `low`
 - `issue_title` - The issue title of the vulnerability, e.g. `Denial os Service (DoS)`. Can be the CVE if the vulnerability is not named by Snyk
 - `ignored` - The issue is ignored in Snyk.
+- `upgradeable` - The issue can be fixed by upgrading to a later version of the dependency.
+- `patchable` - The issue is patchable through Snyk.
 
 Here is an example.
 
 ```
-snyk_vulnerabilities_total{ignored="false",organization="my-org",project="my-app",severity="high",issue_title="Privilege Escalation"} 1.0
-snyk_vulnerabilities_total{ignored="true",organization="my-org",project="my-app",severity="low",issue_title="Sandbox (chroot) Escape"} 2.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false"} 1.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false"} 2.0
 ```
 
 # Build

--- a/snyk.go
+++ b/snyk.go
@@ -141,10 +141,12 @@ type issues struct {
 }
 
 type vulnerability struct {
-	ID       string `json:"id,omitempty"`
-	Severity string `json:"severity,omitempty"`
-	Title    string `json:"title,omitempty"`
-	Ignored  bool   `json:"isIgnored"`
+	ID          string `json:"id,omitempty"`
+	Severity    string `json:"severity,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Ignored     bool   `json:"isIgnored"`
+	Upgradeable bool   `json:"isUpgradable"`
+	Patchable   bool   `json:"isPatchable"`
 }
 
 type license struct{}


### PR DESCRIPTION
This allows for filtering on actionable metrics that can either be fixed
by upgrading the dependency or by patching it through snyk CLI

Closes #19