### PR TITLE
Fix unexpected EOF exits

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,11 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"reflect"
 	"sort"
 	"testing"
@@ -180,4 +183,69 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		// success path if timeout errors are suppressed
 	}
+}
+
+func TestPoll(t *testing.T) {
+	tt := []struct {
+		name         string
+		collectorErr error
+		output       error
+	}{
+		{
+			name:         "no error",
+			collectorErr: nil,
+			output:       nil,
+		},
+		{
+			name:         "custom error",
+			collectorErr: errors.New("custom error"),
+			output:       errors.New("custom error"),
+		},
+		{
+			name:         "unexpected EOF",
+			collectorErr: io.ErrUnexpectedEOF,
+			output:       nil,
+		},
+		{
+			name: "http timeout",
+			collectorErr: &url.Error{
+				Op:  "POST",
+				URL: "/url",
+				Err: &timeoutError{},
+			},
+			output: nil,
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			o := org{
+				ID: tc.name,
+			}
+			err := poll(o, func(org) error {
+				return tc.collectorErr
+			})
+			if tc.output != nil {
+				if err == nil {
+					t.Fatalf("expected output error but got nil")
+				}
+				if tc.output.Error() != err.Error() {
+					t.Fatalf("expected error '%s' but got '%s'", tc.output.Error(), err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected output error '%s'", err)
+			}
+		})
+	}
+}
+
+type timeoutError struct{}
+
+func (err *timeoutError) Timeout() bool {
+	return true
+}
+
+func (err *timeoutError) Error() string {
+	return "timeout error"
 }


### PR DESCRIPTION
The `io.ErrUnexpectedEOF` error was not properly detected as it is not a `net/url` `Error`.

This change extracts the polling and error handling into a separate function, fixes the detection along with adding tests for it.