### PR TITLE
Remove aliased net/url import

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	neturl "net/url"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -174,7 +174,7 @@ func runAPIPolling(done chan error, url, token string, organizationIDs []string,
 func poll(organization org, collector func(org) error) error {
 	err := collector(organization)
 	if err != nil {
-		httpErr, ok := err.(*neturl.Error)
+		httpErr, ok := err.(*url.Error)
 		if ok {
 			if httpErr.Timeout() {
 				log.Errorf("Collection failed for organization '%s' due timeout", organization.Name)


### PR DESCRIPTION
There is no import conflict on the `net/url` package so the alias is redundant and hurts readability.