### PR TITLE
Detect HTTP unexpected EOF errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,6 +180,10 @@ func poll(organization org, collector func(org) error) error {
 				log.Errorf("Collection failed for organization '%s' due timeout", organization.Name)
 				return nil
 			}
+			if httpErr.Err == io.ErrUnexpectedEOF {
+				log.Errorf("Collection failed for organization '%s' due to unexpected EOF", organization.Name)
+				return nil
+			}
 		}
 		if err == io.ErrUnexpectedEOF {
 			log.Errorf("Collection failed for organization '%s' due to unexpected EOF", organization.Name)

--- a/main_test.go
+++ b/main_test.go
@@ -215,6 +215,15 @@ func TestPoll(t *testing.T) {
 			},
 			output: nil,
 		},
+		{
+			name: "http unexpected EOF",
+			collectorErr: &url.Error{
+				Op:  "POST",
+				URL: "/url",
+				Err: io.ErrUnexpectedEOF,
+			},
+			output: nil,
+		},
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Another attempt on handling `io.ErrUnexpectedEOF` errors.
We can see them in `url.Error` errors so this change adds those to the error detection logic.