### PR TITLE
Exit with 0 on OS signals

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,8 @@ func main() {
 	go func() {
 		select {
 		case sig := <-sigs:
-			done <- fmt.Errorf("received os signal '%s'", sig)
+			log.Infof("Received os signal '%s'. Terminating...", sig)
+			done <- nil
 		}
 	}()
 


### PR DESCRIPTION
When receiving `SIGINT` or `SIGTERM` the application is expected to terminate and thus not exit with 1.

This change makes the application log the signal and exit with 0.