### PR TITLE
Upgrade to Go 1.12.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.11.x"
+- "1.12.7"
 script:
 - go build ./...
 - go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11 as builder
+FROM golang:1.12.7 as builder
 WORKDIR /src
 ENV CGO_ENABLED=0
 ENV GOOS=linux


### PR DESCRIPTION
This change upgrades the Go build and runtime to 1.12.7