### PR TITLE
Upgrade to Go 1.13 and Alpine 3.10.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- "1.12.7"
+- "1.13.1"
 script:
 - go build ./...
 - go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.7 as builder
+FROM golang:1.13.1 as builder
 WORKDIR /src
 ENV CGO_ENABLED=0
 ENV GOOS=linux

--- a/Dockerfile-goreleaser
+++ b/Dockerfile-goreleaser
@@ -1,4 +1,4 @@
-FROM alpine:3.8 as builder
+FROM alpine:3.10.3 as builder
 
 RUN apk update
 RUN apk add ca-certificates

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/lunarway/snyk_exporter
 
+go 1.13
+
 require (
 	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect


### PR DESCRIPTION
This PR upgrade Go to the latest release 1.13.1 and Alpine to 3.10.3.
Alpine is used to get certificates only so this a low risk upgrade.