### PR TITLE
Never exit due to HTTP request error

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func runAPIPolling(done chan error, url, token string, organizationIDs []string,
 			log.Debugf("Collecting for organization '%s'", organization.Name)
 			results, err := collect(&client, organization)
 			if err != nil {
-				log.With("error", err).
+				log.With("error", errors.Cause(err)).
 					With("organzationName", organization.Name).
 					With("organzationId", organization.ID).
 					Errorf("Collection failed for organization '%s': %v", organization.Name, err)

--- a/main_test.go
+++ b/main_test.go
@@ -181,13 +181,3 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 		// success path if timeout errors are suppressed
 	}
 }
-
-type timeoutError struct{}
-
-func (err *timeoutError) Timeout() bool {
-	return true
-}
-
-func (err *timeoutError) Error() string {
-	return "timeout error"
-}

--- a/main_test.go
+++ b/main_test.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"errors"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"sort"
 	"testing"
@@ -182,70 +179,6 @@ func TestRunAPIPolling_issuesTimeout(t *testing.T) {
 		}
 	case <-time.After(100 * time.Millisecond):
 		// success path if timeout errors are suppressed
-	}
-}
-
-func TestPoll(t *testing.T) {
-	tt := []struct {
-		name         string
-		collectorErr error
-		output       error
-	}{
-		{
-			name:         "no error",
-			collectorErr: nil,
-			output:       nil,
-		},
-		{
-			name:         "custom error",
-			collectorErr: errors.New("custom error"),
-			output:       errors.New("custom error"),
-		},
-		{
-			name:         "unexpected EOF",
-			collectorErr: io.ErrUnexpectedEOF,
-			output:       nil,
-		},
-		{
-			name: "http timeout",
-			collectorErr: &url.Error{
-				Op:  "POST",
-				URL: "/url",
-				Err: &timeoutError{},
-			},
-			output: nil,
-		},
-		{
-			name: "http unexpected EOF",
-			collectorErr: &url.Error{
-				Op:  "POST",
-				URL: "/url",
-				Err: io.ErrUnexpectedEOF,
-			},
-			output: nil,
-		},
-	}
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			o := org{
-				ID: tc.name,
-			}
-			err := poll(o, func(org) error {
-				return tc.collectorErr
-			})
-			if tc.output != nil {
-				if err == nil {
-					t.Fatalf("expected output error but got nil")
-				}
-				if tc.output.Error() != err.Error() {
-					t.Fatalf("expected error '%s' but got '%s'", tc.output.Error(), err.Error())
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected output error '%s'", err)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
This change removes special handling of collection errors and thus
eliminating exits due to those.
In case of any error due to collection we log the details and move on to
the next available organization.

Closes #36