### PR TITLE
Remove usage of github.com/pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
-	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.1.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 // indirect
 	github.com/prometheus/common v0.7.0

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,7 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/prometheus/common/log"
@@ -147,7 +147,7 @@ func runAPIPolling(done chan error, url, token string, organizationIDs []string,
 			log.Debugf("Collecting for organization '%s'", organization.Name)
 			results, err := collect(&client, organization)
 			if err != nil {
-				log.With("error", errors.Cause(err)).
+				log.With("error", errors.Unwrap(err)).
 					With("organzationName", organization.Name).
 					With("organzationId", organization.ID).
 					Errorf("Collection failed for organization '%s': %v", organization.Name, err)
@@ -222,7 +222,7 @@ type gaugeResult struct {
 func collect(client *client, organization org) ([]gaugeResult, error) {
 	projects, err := client.getProjects(organization.ID)
 	if err != nil {
-		return nil, errors.WithMessage(err, "get projects for organization")
+		return nil, fmt.Errorf("get projects for organization: %w", err)
 	}
 
 	var gaugeResults []gaugeResult


### PR DESCRIPTION
Currently github.com/pkg/errors is used to wrap errors with context.

This functionality has been implemented in the standard library's package errors
and this change drops the direct depdency of pkg/errors.