### PR TITLE
Add logging of the exporters polling activity

### DIFF
--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func runAPIPolling(done chan error, url, token string, organizationIDs []string,
 	for {
 		var gaugeResults []gaugeResult
 		for _, organization := range organizations {
-			log.Debugf("Collecting for organization '%s'", organization.Name)
+			log.Infof("Collecting for organization '%s'", organization.Name)
 			results, err := collect(&client, organization)
 			if err != nil {
 				log.With("error", errors.Unwrap(err)).
@@ -153,8 +153,10 @@ func runAPIPolling(done chan error, url, token string, organizationIDs []string,
 					Errorf("Collection failed for organization '%s': %v", organization.Name, err)
 				continue
 			}
+			log.Infof("Recorded %d results for organization '%s'", len(results), organization.Name)
 			gaugeResults = append(gaugeResults, results...)
 		}
+		log.Infof("Exposing %d results as metrics", len(gaugeResults))
 		scrapeMutex.Lock()
 		register(gaugeResults)
 		scrapeMutex.Unlock()


### PR DESCRIPTION
Currently it is not possible to see from the logs that the polling mechanism is
running.

This changes a debug log to info along with adding a couple of result logs for
each polling run.

```
INFO[0000] Starting Snyk exporter for all organization for token  source="main.go:67"
INFO[0000] Listening on :9532                            source="main.go:101"
INFO[0001] Running Snyk API scraper for organizations: org-1  source="main.go:143"
INFO[0001] Collecting for organization 'org-1'      source="main.go:147"
INFO[0020] Recorded 71 results for organization 'org-1'  source="main.go:156"
INFO[0020] Exposing 71 results as metrics                source="main.go:159"
```