### PR TITLE
Migrate to aggregated issues

### DIFF
--- a/snyk.go
+++ b/snyk.go
@@ -64,7 +64,7 @@ func (c *client) getIssues(organizationID, projectID string) (issuesResponse, er
 	if err != nil {
 		return issuesResponse{}, err
 	}
-	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/org/%s/project/%s/issues", c.baseURL, organizationID, projectID), &reader)
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("%s/org/%s/project/%s/aggregated-issues", c.baseURL, organizationID, projectID), &reader)
 	if err != nil {
 		return issuesResponse{}, err
 	}
@@ -132,21 +132,25 @@ type project struct {
 }
 
 type issuesResponse struct {
-	Issues issues `json:"issues,omitempty"`
+	Issues []issue `json:"issues,omitempty"`
 }
 
-type issues struct {
-	Vulnerabilities []vulnerability `json:"vulnerabilities,omitempty"`
-	Licenses        []license       `json:"licenses,omitempty"`
+type issue struct {
+	ID        string    `json:"id,omitempty"`
+	IssueData issueData `json:"issueData,omitempty"`
+	Ignored   bool      `json:"isIgnored"`
+	FixInfo   fixInfo   `json:"fixInfo,omitempty"`
 }
 
-type vulnerability struct {
-	ID          string `json:"id,omitempty"`
-	Severity    string `json:"severity,omitempty"`
-	Title       string `json:"title,omitempty"`
-	Ignored     bool   `json:"isIgnored"`
-	Upgradeable bool   `json:"isUpgradable"`
-	Patchable   bool   `json:"isPatchable"`
+type issueData struct {
+	ID       string `json:"id,omitempty"`
+	Title    string `json:"title,omitempty"`
+	Severity string `json:"severity,omitempty"`
+}
+
+type fixInfo struct {
+	Upgradeable bool `json:"isUpgradable"`
+	Patchable   bool `json:"isPatchable"`
 }
 
 type license struct{}


### PR DESCRIPTION
Snyk has deprecated the `issues` API endpoint in favour of [`aggregated-issues`](https://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues). The
new endpoint should be more precise and also does some of the logic currently
done in the exporter, ie. deduplication. It also reports vulnerabilities and
license issues as the same entity, ie. issue, which has the positive side effect
that the exporter now tracks license issues as well.

This change updated the endpoint and DTOs and removes the deduplication logic.

The aggregateIssues test is updated to use the new models and naming is aligned
to issues rather than vulnerabilities.

An example of a license issue now reported.

```
snyk_vulnerabilities_total{ignored="false",issue_title="GPL-2.0 license",organization="Squad Nasa",patchable="false",project="some-project",severity="high",upgradeable="false"} 1
```