### PR TITLE
Add issue_type metric label

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 - `organization` - The organization where the vulnerable project exists
 - `project` - The project with a vulnerability
 - `severity` - The severity of the vulnerability, can be `high`, `medium` and `low`
+- `issue_type` - The type of issue, e.g. `vuln`, `license`
 - `issue_title` - The issue title of the vulnerability, e.g. `Denial os Service (DoS)`. Can be the CVE if the vulnerability is not named by Snyk
 - `ignored` - The issue is ignored in Snyk.
 - `upgradeable` - The issue can be fixed by upgrading to a later version of the dependency.
@@ -83,8 +84,9 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 Here is an example.
 
 ```
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false"} 1.0
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false"} 2.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_type="vuln",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false"} 1.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_type="vuln",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false"} 2.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="medium",issue_type="license",issue_title="MPL-2.0 license",ignored="true",upgradeable="false",patchable="false"} 1
 ```
 
 # Build

--- a/snyk.go
+++ b/snyk.go
@@ -137,6 +137,7 @@ type issuesResponse struct {
 
 type issue struct {
 	ID        string    `json:"id,omitempty"`
+	IssueType string    `json:"issueType"`
 	IssueData issueData `json:"issueData,omitempty"`
 	Ignored   bool      `json:"isIgnored"`
 	FixInfo   fixInfo   `json:"fixInfo,omitempty"`


### PR DESCRIPTION
Currently it is not possible to separate vulnerability metrics from license
issue metrics. License issues was added in afdb810a5800d356c98e801c357f531c7a07bbab (#49) as a side effect of changing
the Snyk API endpoint.

This change adds an issue_type label to the exporters metric making it possible
to inspect issues related to license or vulnerabilities explicitly.