### PR TITLE
Add monitored label to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ The API results are aggregated and recorded on the `snyk_vulnerabiilities_total`
 - `ignored` - The issue is ignored in Snyk.
 - `upgradeable` - The issue can be fixed by upgrading to a later version of the dependency.
 - `patchable` - The issue is patchable through Snyk.
+- `monitored` - The project is actively monitored by Snyk.
 
 Here is an example.
 
 ```
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_type="vuln",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false"} 1.0
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_type="vuln",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false"} 2.0
-snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="medium",issue_type="license",issue_title="MPL-2.0 license",ignored="true",upgradeable="false",patchable="false"} 1
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="high",issue_type="vuln",issue_title="Privilege Escalation",ignored="false",upgradeable="false",patchable="false",monitored="true"} 1.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="low",issue_type="vuln",issue_title="Sandbox (chroot) Escape",ignored="true",upgradeable="false",patchable="false",monitored="false"} 2.0
+snyk_vulnerabilities_total{organization="my-org",project="my-app",severity="medium",issue_type="license",issue_title="MPL-2.0 license",ignored="true",upgradeable="false",patchable="false",monitored="true"} 1
 ```
 
 # Build

--- a/main.go
+++ b/main.go
@@ -296,7 +296,7 @@ func collect(ctx context.Context, client *client, organization org) ([]gaugeResu
 			organization: organization.Name,
 			project:      project.Name,
 			results:      results,
-			isMonitored: project.IsMonitored,
+			isMonitored:  project.IsMonitored,
 		})
 		duration := time.Since(start)
 		log.Debugf("Collected data in %v for %s %s", duration, project.ID, project.Name)

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ const (
 	ignoredLabel      = "ignored"
 	upgradeableLabel  = "upgradeable"
 	patchableLabel    = "patchable"
+	monitoredLabel    = "monitored"
 )
 
 var (
@@ -35,7 +36,7 @@ var (
 			Name: "snyk_vulnerabilities_total",
 			Help: "Gauge of Snyk vulnerabilities",
 		},
-		[]string{organizationLabel, projectLabel, issueTypeLabel, issueTitleLabel, severityLabel, ignoredLabel, upgradeableLabel, patchableLabel},
+		[]string{organizationLabel, projectLabel, issueTypeLabel, issueTitleLabel, severityLabel, ignoredLabel, upgradeableLabel, patchableLabel, monitoredLabel},
 	)
 )
 
@@ -264,7 +265,7 @@ func register(results []gaugeResult) {
 	vulnerabilityGauge.Reset()
 	for _, r := range results {
 		for _, result := range r.results {
-			vulnerabilityGauge.WithLabelValues(r.organization, r.project, result.issueType, result.title, result.severity, strconv.FormatBool(result.ignored), strconv.FormatBool(result.upgradeable), strconv.FormatBool(result.patchable)).Set(float64(result.count))
+			vulnerabilityGauge.WithLabelValues(r.organization, r.project, result.issueType, result.title, result.severity, strconv.FormatBool(result.ignored), strconv.FormatBool(result.upgradeable), strconv.FormatBool(result.patchable), strconv.FormatBool(r.isMonitored)).Set(float64(result.count))
 		}
 	}
 }
@@ -272,6 +273,7 @@ func register(results []gaugeResult) {
 type gaugeResult struct {
 	organization string
 	project      string
+	isMonitored  bool
 	results      []aggregateResult
 }
 
@@ -294,6 +296,7 @@ func collect(ctx context.Context, client *client, organization org) ([]gaugeResu
 			organization: organization.Name,
 			project:      project.Name,
 			results:      results,
+			isMonitored: project.IsMonitored,
 		})
 		duration := time.Since(start)
 		log.Debugf("Collected data in %v for %s %s", duration, project.ID, project.Name)

--- a/snyk.go
+++ b/snyk.go
@@ -129,7 +129,7 @@ type projectOrg struct {
 type project struct {
 	Name          string `json:"name,omitempty"`
 	ID            string `json:"id,omitempty"`
-	IsMonitored   bool `json:"isMonitored,omitempty"`
+	IsMonitored   bool   `json:"isMonitored,omitempty"`
 }
 
 type issuesResponse struct {

--- a/snyk.go
+++ b/snyk.go
@@ -127,8 +127,9 @@ type projectOrg struct {
 }
 
 type project struct {
-	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Name          string `json:"name,omitempty"`
+	ID            string `json:"id,omitempty"`
+	IsMonitored   bool `json:"isMonitored,omitempty"`
 }
 
 type issuesResponse struct {


### PR DESCRIPTION
It can be useful to elimate vulnerabilties for projects (files) that are not in use or are not important when Snyk is scanning. You can deactivate these projects on Snyk.io and this PR will now expose that information.