### PR TITLE
Fixed docker login by using correct secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
-          password: ${{ secrets.QUAY_ROBOT_TOKEN }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
https://github.com/lunarway/snyk_exporter/runs/5420105176?check_suite_focus=true currently fails as the secret does not exist.

This change fixes the workflow by using the correct secret