### PR TITLE
Transfer ownership to squad ranger

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @lunarway/squad-nasa
+* @lunarway/squad-ranger


### PR DESCRIPTION
As agreed with @hoeg, we will move the snyk exporter to ranger as all security scanning is located there.